### PR TITLE
[REFACTOR] signup/ signin 함수 네이밍 교체 

### DIFF
--- a/src/app/(auth)/signin/_components/SigninForm.tsx
+++ b/src/app/(auth)/signin/_components/SigninForm.tsx
@@ -1,16 +1,20 @@
 "use client";
 
 import { Form } from "../../signup/_components/Form";
-import { useSigninForm } from "../_hooks/useSigninForm";
+import { SigninFormSchema, useSigninForm } from "../_hooks/useSigninForm";
 import { useSigninMutation } from "../_hooks/useSigninMutation";
 
 export default function SigninForm() {
   const form = useSigninForm();
-  const { handleSignin, isPending } = useSigninMutation();
+  const { signinMutate, isPending } = useSigninMutation();
+
+  const handleSubmit = (data: SigninFormSchema) => {
+    signinMutate(data);
+  };
 
   return (
     <>
-      <Form form={form} onSubmit={handleSignin}>
+      <Form form={form} onSubmit={handleSubmit}>
         <Form.Title>로그인</Form.Title>
 
         {/* 이메일 */}

--- a/src/app/(auth)/signin/_hooks/useSigninMutation.ts
+++ b/src/app/(auth)/signin/_hooks/useSigninMutation.ts
@@ -18,9 +18,9 @@ export function useSigninMutation() {
     },
   });
 
-  const handleSignin = (payload: SigninFormSchema) => {
+  const signinMutate = (payload: SigninFormSchema) => {
     mutate(payload);
   };
 
-  return { handleSignin, isPending };
+  return { signinMutate, isPending };
 }

--- a/src/app/(auth)/signup/_components/SignupForm.tsx
+++ b/src/app/(auth)/signup/_components/SignupForm.tsx
@@ -10,12 +10,12 @@ import { Form } from "./Form";
 
 export default function SignupForm() {
   const form = useSignupForm();
-  const { handleSignup, isPending } = useSignupMutation();
+  const { signupMutate, isPending } = useSignupMutation();
 
   return (
     <>
       <Toaster richColors closeButton position="top-center" />
-      <Form form={form} onSubmit={handleSignup}>
+      <Form form={form} onSubmit={signupMutate}>
         <Form.Title>회원가입</Form.Title>
 
         {/* 이름 */}

--- a/src/app/(auth)/signup/_components/SignupForm.tsx
+++ b/src/app/(auth)/signup/_components/SignupForm.tsx
@@ -3,7 +3,7 @@
 
 import { Toaster } from "@/components/ui/sonner";
 
-import { useSignupForm } from "../_hooks/useSignupForm";
+import { SignupFormSchema, useSignupForm } from "../_hooks/useSignupForm";
 import { useSignupMutation } from "../_hooks/useSignupMutation";
 
 import { Form } from "./Form";
@@ -12,10 +12,14 @@ export default function SignupForm() {
   const form = useSignupForm();
   const { signupMutate, isPending } = useSignupMutation();
 
+  const handleSubmit = (data: SignupFormSchema) => {
+    signupMutate(data);
+  };
+
   return (
     <>
       <Toaster richColors closeButton position="top-center" />
-      <Form form={form} onSubmit={signupMutate}>
+      <Form form={form} onSubmit={handleSubmit}>
         <Form.Title>회원가입</Form.Title>
 
         {/* 이름 */}

--- a/src/app/(auth)/signup/_hooks/useSignupMutation.ts
+++ b/src/app/(auth)/signup/_hooks/useSignupMutation.ts
@@ -24,9 +24,9 @@ export function useSignupMutation() {
     },
   });
 
-  const handleSignup = (payload: SignupFormSchema) => {
+  const signupMutate = (payload: SignupFormSchema) => {
     mutate(payload);
   };
 
-  return { handleSignup, isPending };
+  return { signupMutate, isPending };
 }


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요
로그인 및 회원가입 폼에서 API 호출 함수 이름 변경: handleSignin과 handleSignup을 각각 signinMutate와 signupMutate로 수정함

## 변경 사항
<-- 기능에 대한 구체적인 변경사항을 작성해주세요 -->
- [x] API 호출 함수 이름 변경

## 테스트
<-- 아래 테스트를 다 통과했는지 확인해주세요 -->
- [x] 로컬에서 직접 실행 확인

## 이슈 정보
resolves #41 