### PR TITLE
[REFACTOR] gatherings handler 순서 변경

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 1.2.3(@types/react@19.2.2)(react@19.1.0)
       '@tanstack/react-query':
         specifier: ^5.90.2
-        version: 5.90.2(react@19.1.0)
+        version: 5.90.3(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1065,21 +1065,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/ansi@1.0.0':
-    resolution: {integrity: sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==}
+  '@inquirer/ansi@1.0.1':
+    resolution: {integrity: sha512-yqq0aJW/5XPhi5xOAL1xRCpe1eh8UFVgYFpFsjEqmIR8rKLyP+HINvFXwUaxYICflJrVlxnp7lLN6As735kVpw==}
     engines: {node: '>=18'}
 
-  '@inquirer/confirm@5.1.18':
-    resolution: {integrity: sha512-MilmWOzHa3Ks11tzvuAmFoAd/wRuaP3SwlT1IZhyMke31FKLxPiuDWcGXhU+PKveNOpAc4axzAgrgxuIJJRmLw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/core@10.2.2':
-    resolution: {integrity: sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==}
+  '@inquirer/confirm@5.1.19':
+    resolution: {integrity: sha512-wQNz9cfcxrtEnUyG5PndC8g3gZ7lGDBzmWiXZkX8ot3vfZ+/BLjR8EvyGX4YzQLeVqtAlY/YScZpW7CW8qMoDQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1087,12 +1078,21 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.13':
-    resolution: {integrity: sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==}
+  '@inquirer/core@10.3.0':
+    resolution: {integrity: sha512-Uv2aPPPSK5jeCplQmQ9xadnFx2Zhj9b5Dj7bU6ZeCdDNNY11nhYy4btcSdtDguHqCT2h5oNeQTcUNSGGLA7NTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.14':
+    resolution: {integrity: sha512-DbFgdt+9/OZYFM+19dbpXOSeAstPy884FPy1KjDu4anWwymZeOYhMY1mdFri172htv6mvc/uvIAAi7b7tvjJBQ==}
     engines: {node: '>=18'}
 
-  '@inquirer/type@3.0.8':
-    resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
+  '@inquirer/type@3.0.9':
+    resolution: {integrity: sha512-QPaNt/nmE2bLGQa9b7wwyRJoLZ7pN6rcyXvzU0YCmivmJyq1BVo94G98tStRWkoD1RgDX5C+dPlhhHzNdu/W/w==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1815,11 +1815,11 @@ packages:
   '@tailwindcss/postcss@4.1.14':
     resolution: {integrity: sha512-BdMjIxy7HUNThK87C7BC8I1rE8BVUsfNQSI5siQ4JK3iIa3w0XyVvVL9SXLWO//CtYTcp1v7zci0fYwJOjB+Zg==}
 
-  '@tanstack/query-core@5.90.2':
-    resolution: {integrity: sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==}
+  '@tanstack/query-core@5.90.3':
+    resolution: {integrity: sha512-HtPOnCwmx4dd35PfXU8jjkhwYrsHfuqgC8RCJIwWglmhIUIlzPP0ZcEkDAc+UtAWCiLm7T8rxeEfHZlz3hYMCA==}
 
-  '@tanstack/react-query@5.90.2':
-    resolution: {integrity: sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==}
+  '@tanstack/react-query@5.90.3':
+    resolution: {integrity: sha512-i/LRL6DtuhG6bjGzavIMIVuKKPWx2AnEBIsBfuMm3YoHne0a20nWmsatOCBcVSaT0/8/5YFjNkebHAPLVUSi0Q==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -5726,20 +5726,20 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@inquirer/ansi@1.0.0': {}
+  '@inquirer/ansi@1.0.1': {}
 
-  '@inquirer/confirm@5.1.18(@types/node@20.19.21)':
+  '@inquirer/confirm@5.1.19(@types/node@20.19.21)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.21)
-      '@inquirer/type': 3.0.8(@types/node@20.19.21)
+      '@inquirer/core': 10.3.0(@types/node@20.19.21)
+      '@inquirer/type': 3.0.9(@types/node@20.19.21)
     optionalDependencies:
       '@types/node': 20.19.21
 
-  '@inquirer/core@10.2.2(@types/node@20.19.21)':
+  '@inquirer/core@10.3.0(@types/node@20.19.21)':
     dependencies:
-      '@inquirer/ansi': 1.0.0
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@20.19.21)
+      '@inquirer/ansi': 1.0.1
+      '@inquirer/figures': 1.0.14
+      '@inquirer/type': 3.0.9(@types/node@20.19.21)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
@@ -5748,9 +5748,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.21
 
-  '@inquirer/figures@1.0.13': {}
+  '@inquirer/figures@1.0.14': {}
 
-  '@inquirer/type@3.0.8(@types/node@20.19.21)':
+  '@inquirer/type@3.0.9(@types/node@20.19.21)':
     optionalDependencies:
       '@types/node': 20.19.21
 
@@ -6530,11 +6530,11 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.14
 
-  '@tanstack/query-core@5.90.2': {}
+  '@tanstack/query-core@5.90.3': {}
 
-  '@tanstack/react-query@5.90.2(react@19.1.0)':
+  '@tanstack/react-query@5.90.3(react@19.1.0)':
     dependencies:
-      '@tanstack/query-core': 5.90.2
+      '@tanstack/query-core': 5.90.3
       react: 19.1.0
 
   '@testing-library/dom@10.4.1':
@@ -8700,7 +8700,7 @@ snapshots:
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
-      '@inquirer/confirm': 5.1.18(@types/node@20.19.21)
+      '@inquirer/confirm': 5.1.19(@types/node@20.19.21)
       '@mswjs/interceptors': 0.39.8
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0

--- a/src/mocks/handlers/gatherings.ts
+++ b/src/mocks/handlers/gatherings.ts
@@ -42,6 +42,46 @@ export const gatheringsHandlers = [
     );
   }),
 
+  //================= 찜한 모임 목록 조회 ================================
+  http.get("/api/gatherings/bookmarks", (req) => {
+    const url = new URL(req.request.url);
+    const type = url.searchParams.get("type");
+    const page = Number(url.searchParams.get("page")) || 0;
+    const size = Number(url.searchParams.get("size")) || 10;
+    // const sort = url.searchParams.get("sort") || "createdAt";
+
+    let bookmarkedGatherings = [];
+
+    if (type === EGatheringType.REGULAR) {
+      bookmarkedGatherings = REGULAR_GATHERINGS.filter((gathering) =>
+        isLikedSet.has(gathering.id.toString()),
+      );
+    } else {
+      bookmarkedGatherings = QUICK_GATHERINGS.filter((gathering) =>
+        isLikedSet.has(gathering.id.toString()),
+      );
+    }
+
+    const endIndex = (page + 1) * size;
+    const currentPageData = bookmarkedGatherings.slice(0, endIndex);
+    const hasNext = endIndex < bookmarkedGatherings.length;
+
+    return HttpResponse.json({
+      success: true,
+      code: 0,
+      message: "성공",
+      result: {
+        content: currentPageData,
+        page: page,
+        size: size,
+        totalElements: bookmarkedGatherings.length,
+        totalPages: Math.ceil(bookmarkedGatherings.length / size),
+        last: !hasNext,
+      },
+      errorCode: null,
+    });
+  }),
+
   //================= 모임 상세 조회 ================================
   http.get(`${API_ENDPOINTS.GATHERING}/:id`, (req) => {
     const id = req.params.id;
@@ -162,46 +202,6 @@ export const gatheringsHandlers = [
       code: 200,
       message: "성공",
       result: GATHERING_DETAILS,
-      errorCode: null,
-    });
-  }),
-
-  //================= 찜한 모임 목록 조회 ================================
-  http.get("/api/gatherings/bookmarks", (req) => {
-    const url = new URL(req.request.url);
-    const type = url.searchParams.get("type");
-    const page = Number(url.searchParams.get("page")) || 0;
-    const size = Number(url.searchParams.get("size")) || 10;
-    // const sort = url.searchParams.get("sort") || "createdAt";
-
-    let bookmarkedGatherings = [];
-
-    if (type === EGatheringType.REGULAR) {
-      bookmarkedGatherings = REGULAR_GATHERINGS.filter((gathering) =>
-        isLikedSet.has(gathering.id.toString()),
-      );
-    } else {
-      bookmarkedGatherings = QUICK_GATHERINGS.filter((gathering) =>
-        isLikedSet.has(gathering.id.toString()),
-      );
-    }
-
-    const endIndex = (page + 1) * size;
-    const currentPageData = bookmarkedGatherings.slice(0, endIndex);
-    const hasNext = endIndex < bookmarkedGatherings.length;
-
-    return HttpResponse.json({
-      success: true,
-      code: 0,
-      message: "성공",
-      result: {
-        content: currentPageData,
-        page: page,
-        size: size,
-        totalElements: bookmarkedGatherings.length,
-        totalPages: Math.ceil(bookmarkedGatherings.length / size),
-        last: !hasNext,
-      },
       errorCode: null,
     });
   }),


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요

<!-- 어떤 기능에 대한 PR인지 설명해주세요 -->
**버그**
찜한 목록의 API 가 무한으로 호출됨

**원인**
msw handler에서
```tsx
http.get("/api/gatherings/:id", ...) // (1) 모임 정보 상세 조회
http.get(""/api/gatherings/bookmarks", ...) // (2) 내가 찜한 모임 목록 조회
```
두 개가 존재했는데, (2)번을 호출했을 때 (1)번의 response가 자꾸 나옴
:id가 bookmarks로 인식됐기 때문
-> 두 개의 순서를 바꿔줌으로써 `/bookmark`가 아니라면 `/:id`로 처리될 수 있도록 함

## 변경 사항

<!-- 기능에 대한 구체적인 변경사항을 작성해주세요 -->

- [x] gatherings handler 순서 변경

## 스크린샷(선택)

<!-- 눈에 띄는 변경 사항(UI 등)이 있다면 이미지를 첨부해주세요 -->

## 이슈 정보

<!-- PR과 연결할 관련 이슈를 적어주세요 (자동으로 닫히지 않음) -->

resolves #95 
