### PR TITLE
[DESIGN] 버튼 크기 변수 조정, 레이아웃 통일

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,10 +22,10 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        sm: "h-7 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-8 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
-        xl: "h-11 px-8 py-3 text-base font-semibold rounded-[10px] has-[>svg]:px-4",
+        xl: "h-10 px-8 py-3 text-base font-semibold rounded-[10px] has-[>svg]:px-4",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요  
버튼 컴포넌트의 변형별 크기를 조정하여 일관성을 높였고,  
테스트 환경에서 자동으로 실행되던 Mock Service Worker를 비활성화했습니다.  

## 변경 사항  
- [x] Button 컴포넌트 크기 단위 정리  
- [x] initMocks에서 `worker.start()` 주석 처리  

## 테스트  
- [x] 각 버튼 변형별 시각적 일관성 확인  
- [x] 테스트 실행 시 Mock Worker가 자동으로 시작되지 않는지 확인  

## 이슈 정보  
resolves #123