### PR TITLE
[REFACTOR] 모달 폼 리셋 및 첫 로그인 상태 갱신 로직 개선

### DIFF
--- a/src/components/Modal/PetInfoModal/PetInfoModal.tsx
+++ b/src/components/Modal/PetInfoModal/PetInfoModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
@@ -39,6 +40,22 @@ export default function PetInfoModal() {
     hasChanges,
   } = usePetInfoModal({ type: type || "add-pet", petId });
   const currentImage = form.watch("image");
+
+  // 모달이 열릴 때마다 form 리셋
+  useEffect(() => {
+    if (isOpen && (type === "first-login" || type === "add-pet")) {
+      // add 모드인 경우 빈 폼으로 리셋
+      form.reset({
+        name: "",
+        birthYear: "",
+        image: null,
+        breed: "",
+        gender: undefined,
+        neuter: undefined,
+        petType: "dog",
+      });
+    }
+  }, [isOpen, type, form]);
 
   const { handleSubmit, isSubmitting } = usePetInfoSubmit({
     type: type || "add-pet",
@@ -85,7 +102,7 @@ export default function PetInfoModal() {
 
   return (
     <Modal>
-      <Modal.CloseBtn />
+      {type !== "first-login" && <Modal.CloseBtn />}
 
       {type === "first-login" ? (
         <Modal.Title

--- a/src/components/Modal/PetInfoModal/hooks/usePetInfoModal.ts
+++ b/src/components/Modal/PetInfoModal/hooks/usePetInfoModal.ts
@@ -39,7 +39,7 @@ export function usePetInfoModal({
         petType: "dog",
       });
     }
-  }, [form, isEditMode]);
+  }, [form, isEditMode, type]);
 
   useEffect(() => {
     if (initialData) {

--- a/src/components/Modal/PetInfoModal/hooks/usePetInfoSubmit.ts
+++ b/src/components/Modal/PetInfoModal/hooks/usePetInfoSubmit.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { ImageUploadRes } from "@/api/types/pets";
 import { useUploadPetImage } from "@/hooks/queries/imageUpload";
 import { usePostPet, usePutPet } from "@/hooks/queries/pets";
+import { useUpdateMyInfo } from "@/hooks/queries/user";
 import { PATH } from "@/lib/constants/path";
 
 import { PetInfoModalProps } from "../types/petInfoModal";
@@ -18,6 +19,7 @@ export function usePetInfoSubmit({
   const router = useRouter();
 
   const createPetMutation = usePostPet();
+  const updateMyInfoMutation = useUpdateMyInfo(); // first-login 시 isPetInfoSubmitted true로 수정
   const updatePetMutation = usePutPet();
   const uploadImageMutation = useUploadPetImage();
 
@@ -80,6 +82,9 @@ export function usePetInfoSubmit({
           toast.success("반려동물 정보가 등록되었습니다.");
           onClose();
           if (type === "first-login") {
+            await updateMyInfoMutation.mutateAsync({
+              isPetInfoSubmitted: true,
+            });
             router.push(PATH.REGULAR);
           }
         } catch (error) {

--- a/src/components/Modal/ReviewInfoModal/ReviewInfoModal.tsx
+++ b/src/components/Modal/ReviewInfoModal/ReviewInfoModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { toast } from "sonner";
 
 import { Form } from "@/components/Form";
@@ -23,6 +24,17 @@ export default function ReviewInfoModal() {
     modalType,
     reviewId,
   });
+
+  // 모달이 열릴 때마다 form 리셋
+  useEffect(() => {
+    if (isOpen && modalType === "add-review") {
+      // add 모드인 경우 빈 폼으로 리셋
+      form.reset({
+        score: undefined,
+        comment: "",
+      });
+    }
+  }, [isOpen, modalType, form]);
 
   // Store에서 읽은 값으로 props 구성
   const submitProps =

--- a/src/components/Modal/ReviewInfoModal/hooks/useReviewInfoModal.ts
+++ b/src/components/Modal/ReviewInfoModal/hooks/useReviewInfoModal.ts
@@ -54,7 +54,7 @@ export function useReviewInfoModal({
         comment: "",
       });
     }
-  }, [form, isEditMode]);
+  }, [form, isEditMode, modalType]);
 
   useEffect(() => {
     if (initialData) {

--- a/src/components/Modal/UserInfoModal/UserInfoModal.tsx
+++ b/src/components/Modal/UserInfoModal/UserInfoModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import Person from "@/assets/images/profile.svg";
 import { Form } from "@/components/Form";

--- a/src/components/Modal/UserInfoModal/hooks/useUserInfoModal.ts
+++ b/src/components/Modal/UserInfoModal/hooks/useUserInfoModal.ts
@@ -39,7 +39,7 @@ export function useUserInfoModal({
         image: null,
       });
     }
-  }, [form, isEditMode]);
+  }, [form, isEditMode, type]);
 
   useEffect(() => {
     if (initialData) {


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요
수정모달이 열릴 때마다 initial데이터만 초기화할뿐, first-login 혹은 add-review 시에는 이전 폼이 남아있던 문제가 있어 리팩토링/버그픽스를 진행하였습니다.
- 폼이 자동으로 초기화되도록 개선했습니다.  
- 또한 `type` 의존성을 추가해 모달 상태 관리의 안정성을 높였으며,  
- 첫 로그인 시 `isPetInfoSubmitted`가 갱신되지 않던 문제를 해결했습니다.  
- 이제 `usePetInfoSubmit` 훅 내부에서 유저 정보 업데이트까지 한 번에 처리됩니다.

## 변경 사항
- [x] `PetInfoModal`, `ReviewInfoModal` 폼 초기화 로직 추가  
- [x] `usePetInfoModal`, `useUserInfoModal` 의존성 배열에 `type` 추가  
- [x] `usePetInfoSubmit` 내 유저 정보 업데이트 및 `isPetInfoSubmitted` 상태 갱신 추가  

## 테스트
- [x] 모달 열기/닫기 시 폼 초기화 정상 동작 확인  
- [x] 첫 로그인 시 `isPetInfoSubmitted` 정상 업데이트 확인  
- [x] 이후 로그인 시 중복 호출 없이 정상 동작 확인  

## 이슈 정보
resolves #211 




