### PR TITLE
[BUG] 정기 모임 생성 시 모임 날짜 자동저장 이상

### DIFF
--- a/src/components/Form/FormCheckbox.tsx
+++ b/src/components/Form/FormCheckbox.tsx
@@ -38,6 +38,7 @@ export function Checkbox({
             name={name}
             id={option.id}
             className="peer sr-only"
+            checked={value.includes(option.value)}
             onChange={(e) => handleChange(option.value, e.target.checked)}
           />
           <label


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요

<!-- 어떤 기능에 대한 PR인지 설명해주세요 -->
정기 모임 생성 페이지의 자동저장 기능에서 days 필드(모임 날짜) 복원 시 시각적 상태가 반영되지 않는 문제를 해결했습니다. 
사용자가 요일을 선택하고 페이지를 나갔다가 다시 들어왔을 때, 데이터는 복원되지만 체크박스가 선택된 상태로 표시되지 않던 버그를 수정했습니다.

## 변경 사항

<!-- 기능에 대한 구체적인 변경사항을 작성해주세요 -->

- [x] FormCheckbox 컴포넌트에 `checked={value.includes(option.value)}` 속성 추가
- [x] React Hook Form의 `form.reset()`으로 복원된 데이터가 체크박스 UI에 시각적으로 반영되도록 수정
- [x] 정기 모임 생성 페이지에서 선택한 요일이 페이지 재진입 시 올바르게 표시되도록 개선

## 스크린샷(선택)

<!-- 눈에 띄는 변경 사항(UI 등)이 있다면 이미지를 첨부해주세요 -->
![정기 모임 날짜 자동저장 복원](https://github.com/user-attachments/assets/5c353650-4753-40c2-b663-f97b112f5e95)


## 이슈 정보

<!-- PR과 연결할 관련 이슈를 적어주세요 (자동으로 닫히지 않음) -->

resolves #213 