### PR TITLE
[REFACTOR] AuthRequiredModal 및 ConfirmModal 버튼 variant 통일 및 로직 단순화  

### DIFF
--- a/src/components/Modal/AuthRequiredModal/AuthRequiredModal.tsx
+++ b/src/components/Modal/AuthRequiredModal/AuthRequiredModal.tsx
@@ -30,7 +30,7 @@ export default function AuthRequiredModal() {
               onClose?.();
             }}
             className="h-10 w-1/2"
-            variant="gray"
+            variant="outline"
           >
             이전으로
           </Button>

--- a/src/components/Modal/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal/ConfirmModal.tsx
@@ -22,7 +22,7 @@ export default function ConfirmModal() {
               closeModal();
             }}
             className="h-10 w-1/2"
-            variant="gray"
+            variant="outline"
           >
             닫기
           </Button>
@@ -32,13 +32,7 @@ export default function ConfirmModal() {
               onConfirm?.();
             }}
             className="h-10 w-1/2"
-            variant={
-              text === "개설 취소"
-                ? "destructive"
-                : text === "참여 취소"
-                  ? "outline"
-                  : "default"
-            }
+            variant="default"
           >
             {text}
           </Button>


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요  
AuthRequiredModal과 ConfirmModal의 버튼 variant를 통일하고 불필요한 조건 분기를 제거했습니다.  
디자인 시스템 내 일관성을 높이고, 버튼 로직을 단순화했습니다.  

## 변경 사항  
- [x] AuthRequiredModal 버튼 variant를 `gray` → `outline`으로 변경  
- [x] ConfirmModal 버튼 variant 로직을 단일 `default`로 변경  

## 테스트  
- [x] AuthRequiredModal에서 버튼 스타일 정상 표시 확인  
- [x] ConfirmModal에서 variant 변경 후 정상 동작 확인  

## 이슈 정보  
resolves #248 