### PR TITLE
[REFACTOR] 최소 n초 렌더링하는 로직 훅으로 분리

### DIFF
--- a/src/components/InfiniteScroll.tsx
+++ b/src/components/InfiniteScroll.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 import { UseInfiniteQueryResult } from "@tanstack/react-query";
 
+import useMinimumRendering from "@/hooks/useMinimumRendering";
 import { DEFAULT_LIST_OPTIONS } from "@/lib/constants/option";
 import { cn } from "@/lib/utils";
 
@@ -43,25 +44,15 @@ export default function InfiniteScroll<T>({
   minimumLoadingTime = 500,
 }: InfiniteScrollProps<T>) {
   const { ref, inView } = useInView();
-  const [showSkeleton, setShowSkeleton] = useState(isPending);
+  const { isRendering } = useMinimumRendering({
+    minRenderTime: minimumLoadingTime,
+  });
 
   useEffect(() => {
     if (inView) fetchNextPage();
   }, [inView, fetchNextPage]);
 
-  useEffect(() => {
-    if (isPending) {
-      setShowSkeleton(true);
-    } else {
-      const timer = setTimeout(() => {
-        setShowSkeleton(false);
-      }, minimumLoadingTime);
-
-      return () => clearTimeout(timer);
-    }
-  }, [isPending, minimumLoadingTime]);
-
-  if (showSkeleton)
+  if (isPending || isRendering)
     return (
       <ul className={cn("grid grid-cols-1 gap-y-6", className)}>
         <Iterator count={DEFAULT_LIST_OPTIONS.size}>

--- a/src/hooks/useMinimumRendering.tsx
+++ b/src/hooks/useMinimumRendering.tsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+interface UseMinimumRenderingProps {
+  minRenderTime?: number;
+}
+
+function useMinimumRendering({
+  minRenderTime = 400,
+}: UseMinimumRenderingProps) {
+  const [isMinRenderTimePassed, setIsMinRenderTimePassed] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsMinRenderTimePassed(false);
+    }, minRenderTime);
+
+    return () => clearTimeout(timer);
+  }, [minRenderTime]);
+
+  return { isRendering: isMinRenderTimePassed };
+}
+
+export default useMinimumRendering;


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요
로직 분리 리팩토링

## 변경 사항
- [x] 최소 n초 렌더링하는 로직을 `useMinimumRendering` 훅으로 분리하였습니다

## 이슈 정보

<!-- PR과 연결할 관련 이슈를 적어주세요 (자동으로 닫히지 않음) -->
resolves #189 
