### PR TITLE
[BUGFIX] mock data key 중복 에러

### DIFF
--- a/src/mocks/data/users.ts
+++ b/src/mocks/data/users.ts
@@ -4,7 +4,7 @@ import { UserType } from "@/lib/types/user";
  * Mock 사용자 데이터
  */
 export const mockCurrentUser: UserType = {
-  id: 1,
+  id: 99999,
   email: "test@test.com",
   name: "멍로드",
   nickName: "멍로드",


### PR DESCRIPTION
참가자를 조회할 때,
currentUser(현재 로그인 된 유저)라는 목데이터와 mockUsers의 데이터를 앞에서부터 잘라서 주는데,
```tsx
[currentUser, ...mockUsers] // 이런식으로요!
```
currentUser와 mockUsers[0]의 아이디가 둘 다 1로 key가 중복돼서 생긴 (로컬에서만 발생하는) 이슈였습니다!

→ currentUser의 id를 99999로 변경하여 겹치지 않도록 했습니다!

___

resolves #288 