### PR TITLE
[FIX] 모임 마감 필터 매핑 오류 및 상태 판별 우선순위 개선

### DIFF
--- a/src/components/widget/filters/FilterPopover.tsx
+++ b/src/components/widget/filters/FilterPopover.tsx
@@ -40,7 +40,7 @@ export default function FilterPopover({ type }: FilterPopoverProps) {
   const { isPetRequired, isClosed, dayOfWeek, startDate, endDate } =
     useSearchParamsState({
       isPetRequired: PET_REQUIRED_OPTIONS[0].id,
-      isClosed: IS_CLOSED_OPTIONS[0].id,
+      isClosed: IS_CLOSED_OPTIONS[1].id,
     });
 
   const [date, setDate] = useState<DateRange>({

--- a/src/lib/constants/option.ts
+++ b/src/lib/constants/option.ts
@@ -150,11 +150,11 @@ export const IS_CLOSED_OPTIONS_MAP: Record<
   { value?: boolean; label: string }
 > = {
   [EIsClosed.SHOW_CLOSED]: {
-    value: undefined,
+    value: true,
     label: "모임 마감된 모임도 표시",
   },
   [EIsClosed.HIDE_CLOSED]: {
-    value: true,
+    value: false,
     label: "모임 마감된 모임은 보지 않기",
   },
 };

--- a/src/lib/utils/gathering.ts
+++ b/src/lib/utils/gathering.ts
@@ -33,14 +33,18 @@ export const getGatheringState = (
   isAuthenticated: boolean,
   hasPet: boolean,
 ) => {
-  if (!isAuthenticated) return EGatheringState.AUTH_REQUIRED;
+  // 인증 여부와 관계없이 먼저 체크: 취소여부, 모집 마감, 인원 마감
+  if (gathering.canceledAt !== null) return EGatheringState.CANCELED;
   if (checkIsBefore(gathering.registrationEnd))
     return EGatheringState.REGISTRATION_END_PASSED;
-  if (gathering.isPetRequired && !hasPet) return EGatheringState.PET_REQUIRED;
-  if (gathering.participantCount >= 5) return EGatheringState.FIXED_GATHERING;
   if (gathering.participantCount >= gathering.capacity)
     return EGatheringState.CAPACITY_FULL;
-  if (gathering.canceledAt !== null) return EGatheringState.CANCELED;
+
+  // 인증 필요 상태: 로그인 안 한 사용자, 반려견 필수 여부, 모임 개설 확정
+  if (!isAuthenticated) return EGatheringState.AUTH_REQUIRED;
+  if (gathering.isPetRequired && !hasPet) return EGatheringState.PET_REQUIRED;
+  if (gathering.participantCount >= 5) return EGatheringState.FIXED_GATHERING;
+
   return EGatheringState.GENERAL;
 };
 


### PR DESCRIPTION



## 어떤 변경인가요?
모임 마감 필터와 상태 판별 로직의 의미 불일치를 수정하고,  
모든 사용자에게 일관된 모임 상태 오버레이가 보이도록 개선했습니다.

## 변경 사항
- [x] `isClosed` 옵션 값 수정 (`true/false` 의미 정정)
- [x] 필터 기본값을 `HIDE_CLOSED`로 변경
- [x] 모임 상태 판별 로직 우선순위 재정렬
  - 취소 → 모집마감 → 인원마감 → 인증 관련 상태
- [x] 비로그인 사용자에게도 마감/취소 오버레이 표시

## 테스트
- [x] 마감 필터 체크/해제 시 동작 확인
- [x] 페이지 최초 진입 시 필터 기본값 확인
- [x] 로그인/비로그인 상태별 모임 상태 오버레이 확인

## 이슈 정보
resolves #298 