### PR TITLE
[FIX] 주소에 맞는 지도가 제대로 표시되지 않는 버그 수정

### DIFF
--- a/src/app/(gatherings)/_components/GatheringDetail/GatheringLocationSection.tsx
+++ b/src/app/(gatherings)/_components/GatheringDetail/GatheringLocationSection.tsx
@@ -16,6 +16,7 @@ export default function GatheringLocationSection({
 
   useEffect(() => {
     if (!mapRef.current) return;
+
     kakaoMapService.createStaticMap(mapRef.current, locationPayload);
   }, [locationPayload]);
 

--- a/src/app/(gatherings)/quick/[id]/page.tsx
+++ b/src/app/(gatherings)/quick/[id]/page.tsx
@@ -45,9 +45,7 @@ function QuickGatheringDetailPageContent() {
   return (
     <>
       <GatheringInfoSection gathering={gathering} />
-      <GatheringLocationSection
-        locationPayload={JSON.parse(gathering.location).region_2depth_name}
-      />
+      <GatheringLocationSection locationPayload={gathering.location} />
       <GatheringIntroductionSection description={gathering.description} />
     </>
   );

--- a/src/app/(gatherings)/regular/[id]/page.tsx
+++ b/src/app/(gatherings)/regular/[id]/page.tsx
@@ -48,9 +48,7 @@ function RegularGatheringDetailPageContent() {
   return (
     <>
       <GatheringInfoSection gathering={gathering} />
-      <GatheringLocationSection
-        locationPayload={JSON.parse(gathering.location).region_2depth_name}
-      />
+      <GatheringLocationSection locationPayload={gathering.location} />
       <GatheringIntroductionSection description={gathering.description} />
       <GatheringReviewSection />
     </>


### PR DESCRIPTION
## 어떤 기능인지 설명해주세요
모임 주소에 맞는 지도가 제대로 표시되도록 수정했습니다
마지막 수정 때 잘못 변경했던 것 같습니다 (모임 카드에서 "구" 정보만 쓰고 있어서 헷갈렸던 것 같아요)

## 변경 사항
- [x] `GatheringLocationSection`의 `locationPayload`를 "구" 정보가 아니라 파싱된 오브젝트를 전달하도록 바꿨습니다

## 테스트
- [x] 프로덕션 환경에서 직접 실행 확인

## 이슈 정보
related to: #307